### PR TITLE
Remove final from some classes and methods to allow proxying

### DIFF
--- a/src/main/java/com/jetbrains/jdi/ClassTypeImpl.java
+++ b/src/main/java/com/jetbrains/jdi/ClassTypeImpl.java
@@ -55,7 +55,7 @@ import com.sun.jdi.ThreadReference;
 import com.sun.jdi.Value;
 import com.sun.jdi.VirtualMachine;
 
-final public class ClassTypeImpl extends InvokableTypeImpl
+public class ClassTypeImpl extends InvokableTypeImpl
                                  implements ClassType
 {
     private static class IResult implements InvocationResult {

--- a/src/main/java/com/jetbrains/jdi/InterfaceTypeImpl.java
+++ b/src/main/java/com/jetbrains/jdi/InterfaceTypeImpl.java
@@ -50,7 +50,7 @@ import com.sun.jdi.Method;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.VirtualMachine;
 
-final public class InterfaceTypeImpl extends InvokableTypeImpl
+public class InterfaceTypeImpl extends InvokableTypeImpl
                                      implements InterfaceType {
 
     private static class IResult implements InvocationResult {

--- a/src/main/java/com/jetbrains/jdi/InvokableTypeImpl.java
+++ b/src/main/java/com/jetbrains/jdi/InvokableTypeImpl.java
@@ -106,7 +106,7 @@ abstract class InvokableTypeImpl extends ReferenceTypeImpl {
      *         compatibility.
      * @throws VMCannotBeModifiedException if the VirtualMachine is read-only - see {@link VirtualMachine#canBeModified()}.
      */
-    final public Value invokeMethod(ThreadReference threadIntf, Method methodIntf,
+    public Value invokeMethod(ThreadReference threadIntf, Method methodIntf,
                                     List<? extends Value> origArguments, int options)
                                         throws InvalidTypeException,
                                                ClassNotLoadedException,
@@ -214,7 +214,7 @@ abstract class InvokableTypeImpl extends ReferenceTypeImpl {
      * {@linkplain InterfaceType#allMethods()}
      * @return A list of all methods (recursively)
      */
-    public final List<Method> allMethods() {
+    public List<Method> allMethods() {
         ArrayList<Method> list = new ArrayList<>(methods());
         ClassType clazz = superclass();
         while (clazz != null) {


### PR DESCRIPTION
This will allow JRebel to proxy these classes so that various `instanceof` checks (e.g. in DebuggerUtilsAsync) will pass and use the *Async and other added methods.