### PR TITLE
Unhandled MISSING_SLOT error in GetValues

### DIFF
--- a/src/main/java/com/jetbrains/jdi/StackFrameImpl.java
+++ b/src/main/java/com/jetbrains/jdi/StackFrameImpl.java
@@ -500,6 +500,7 @@ public class StackFrameImpl extends MirrorImpl
                 case JDWP.Error.INVALID_FRAMEID:
                 case JDWP.Error.THREAD_NOT_SUSPENDED:
                 case JDWP.Error.INVALID_THREAD:
+                case JDWP.Error.INVALID_SLOT:
                     throw new InvalidStackFrameException();
                 default:
                     throw exc.toJDIException();


### PR DESCRIPTION
Debugging an ART vm results in Exception being thrown.

com.sun.jdi.InternalException: Unexpected JDWP Error: 35
	at com.jetbrains.jdi.JDWPException.toJDIException(JDWPException.java:96)
	at com.jetbrains.jdi.StackFrameImpl.getArgumentValues(StackFrameImpl.java:505)
	at com.intellij.idea.IdeaLogger.error(IdeaLogger.java:130)
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:388)

Error 35 is INVALID_SLOT and is a valid error return code from StackFrame.GetValues.